### PR TITLE
chore: Ensure LF line-endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+package-lock.json -diff

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
     - main
     paths-ignore:
     - .editorconfig
+    - .gitattributes
     - .gitignore
     - .prettierignore
     - action.yaml
@@ -38,6 +39,7 @@ jobs:
 
   dogfood-linux:
     name: Dogfood (ubuntu-latest)
+    needs: [ verify ]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -57,6 +59,7 @@ jobs:
 
   dogfood-windows:
     name: Dogfood (windows-latest)
+    needs: [ verify ]
     runs-on: windows-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,7 @@ on:
     - main
     paths-ignore:
     - .editorconfig
+    - .gitattributes
     - .gitignore
     - .prettierignore
     - action.yaml


### PR DESCRIPTION
When GitHub Actions checks out code on a Windows runner, it converts the line endings to CRLF, this causes Prettier to think that the code is not formatted correctly on Windows, this commit should prevent that from happening.